### PR TITLE
Add the ability to allow specific hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Settings are stored in `settings.json`
 |------------|---------------
 |`dnsZone`     | The Google Cloud DNS Zone name in which the records reside.
 |`secretToken` | A secret token, used to authenticate users.
+|`allowedHosts`| A list of hosts that callers are allowed to update. May include `"*"` to allow all hosts.
 |`ttl`         | Time to live for records in seconds.
 
 To be able to authenticate against the Google Cloud DNS API, an environment variable `GOOGLE_APPLICATION_CREDENTIALS` must be set, which points to a valid [credentials.json](https://cloud.google.com/docs/authentication/production). The Google Cloud project name is read from the env var `GCLOUD_PROJECT`.

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ exports.updateHost = function(req, res) {
     }
 
     if (!settings.allowedHosts.includes('*') && !settings.allowedHosts.includes(host)) {
-        respondWithError(403, 'illegal host', 'Host "' + host + '" is not allowed', res);
+        respondWithError(401, 'illegal host', 'Host "' + host + '" is not allowed', res);
         return;
     }
 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,11 @@ exports.updateHost = function(req, res) {
         return;
     }
 
+    if (!settings.allowedHosts.includes('*') && !settings.allowedHosts.includes(host)) {
+        respondWithError(403, 'illegal host', 'Host "' + host + '" is not allowed', res);
+        return;
+    }
+
     if (!host.endsWith('.')) {
         host += '.';
     }

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,6 @@
 {
     "dnsZone": "zone-name",
     "secretToken": "such secret!",
+    "allowedHosts": ["*"],
     "ttl": "10"
 }


### PR DESCRIPTION
In my use case, the machine responsible for making calls to the Cloud Function has unencrypted storage. I do not want anyone who acquires physical access to the device to be able to update arbitrary hosts on my domain, and GCP apparently does not support granular enough permissions to give a Service Account the ability to update only a specific set of hostnames.

This pull request would allow users to specify a list of hosts that callers are allowed to update using the `allowedHosts` configuration option. By default, all hosts are allowed using a wildcard string (`"*"`).